### PR TITLE
Windows path compatibility

### DIFF
--- a/url/url.go
+++ b/url/url.go
@@ -18,7 +18,7 @@ func Parse(i string) (o *url.URL, err error) {
 	// File
 	if o.Scheme == "" {
 		// Get absolute path
-		if i, err = filepath.Abs(i); err != nil {
+		if i, err = filepath.ToSlash(filepath.Abs(i)); err != nil {
 			err = errors.Wrapf(err, "getting absolute path of %s failed", i)
 			return
 		}


### PR DESCRIPTION
Referencing [this issue](https://github.com/asticode/go-astilectron/issues/100). I changed the paths to use `/` instead of `\`, to work around an error when loading local files on Windows. It seems to prevent URL encoding on my Windows environment, which allows Electron to recognize the path properly.